### PR TITLE
Correct spelling of lowercase json to uppercase

### DIFF
--- a/source/cash_point_api.html.md
+++ b/source/cash_point_api.html.md
@@ -13,10 +13,10 @@ search: true
 
 # Preparation
 
-Before you can use the go~mus Cash Point API you will have to register a cash point account with an API key. 
+Before you can use the go~mus Cash Point API you will have to register a cash point account with an API key.
 Please talk to your contact person in order to get access.
 
-See [detailed documentation on Public API](/public_api.html) for information on how to request the basic data 
+See [detailed documentation on Public API](/public_api.html) for information on how to request the basic data
 for events, tours and tickets.
 
 
@@ -36,7 +36,7 @@ for the orders placed by the cash point, the filter `only_my_orders` is provided
 
 - only_my_orders (boolean, true|false, default: all)
 
-See [detailed documentation on Reseller API](/reseller_api.html) for information on how to create an order 
+See [detailed documentation on Reseller API](/reseller_api.html) for information on how to create an order
 for events, tours and tickets against the orders end point.
 
 # Bookings
@@ -141,7 +141,7 @@ curl "https://demo.gomus.de/api/v4/events/123/dates/456/bookings"
 
 ### Response
 
-The json response contains a list of existing bookings as an array and a meta block.
+The JSON response contains a list of existing bookings as an array and a meta block.
 
 - id (integer), the unique database id of the booking
 - customer (object), contains name, category and institution reference
@@ -149,7 +149,7 @@ The json response contains a list of existing bookings as an array and a meta bl
 - status (integer, any of BOOKED=20, CANCELED=60)
 - seats (integer) number of booked seats
 - prices (array)
-    
+
 ## Tour bookings
 
 The cash point can access all individual tour bookings via the tours bookings endpoint.
@@ -222,7 +222,7 @@ curl "https://demo.gomus.de/api/v4/tours/bookings"
 - by_categories (Array of category names), filter by categories, see categories section
 - by_status_ids (Array, any of BOOKED=20, CANCELED=50, FINISHED=25)
 
-  
+
 ### Available parameters:
 
 - start_at, order date (`YYYY-MM-DD`), defaults to beginning of today
@@ -232,7 +232,7 @@ curl "https://demo.gomus.de/api/v4/tours/bookings"
 
 ### Response
 
-The json response contains a list of existing bookings as an array and a meta block.
+The JSON response contains a list of existing bookings as an array and a meta block.
 
 - id (integer), the unique database id of the booking
 - start_time (iso8601), the booking's timestamp
@@ -306,7 +306,7 @@ curl "https://demo.gomus.de/api/v4/tours/bookings/1"
 
 ### Response
 
-The json response contains details for a booking like in the list view, but with a few additional information.
+The JSON response contains details for a booking like in the list view, but with a few additional information.
 
 - prices: an array of price objects, containing both default and custom booking prices.
 
@@ -314,7 +314,7 @@ The json response contains details for a booking like in the list view, but with
 
 ## Changing prices
 
-It is possible to add and update custom booking prices unless the booking has been payed already. It is not possible 
+It is possible to add and update custom booking prices unless the booking has been payed already. It is not possible
 to change the default prices but e.g. give a discount and add additional custom items.
 
 Note that the cash point has only access to customer booking prices and can change only custom type prices.

--- a/source/entry_api.html.md
+++ b/source/entry_api.html.md
@@ -123,7 +123,7 @@ curl "https://demo.gomus.de/api/v4/entry/scans/3"
 
 ### Response
 
-The json response contains a serialized scan event.
+The JSON response contains a serialized scan event.
 
 
 ## Exit API - Tracking exits

--- a/source/includes/v4/_events.md
+++ b/source/includes/v4/_events.md
@@ -33,7 +33,7 @@ curl "https://demo.gomus.de/api/v4/events/categories"
 
 ### Response
 
-The json response contains a list of all event categories to build up filters.
+The JSON response contains a list of all event categories to build up filters.
 Note: this only contains valid elements, some events might have no name set. Some categories have
 duplicate names.
 
@@ -65,7 +65,7 @@ curl "https://demo.gomus.de/api/v4/events/languages"
 
 ### Response
 
-The json response contains a list of all languages used by online bookable event products to build up filters.
+The JSON response contains a list of all languages used by online bookable event products to build up filters.
 
 ## Event tags
 
@@ -200,7 +200,7 @@ curl "https://demo.gomus.de/api/v4/events/grades"
 
 ### Tag responses
 
-The json response contains a list of used event tags by category to build up filters.
+The JSON response contains a list of used event tags by category to build up filters.
 
 
 ## List of events
@@ -296,7 +296,7 @@ curl "https://demo.gomus.de/api/v4/events"
 
 ### Response
 
-The json response contains a list of events as an array and a meta block.
+The JSON response contains a list of events as an array and a meta block.
 
 - id (integer), the unique database id of the event
 - title (string), the name of the event
@@ -400,7 +400,7 @@ Queries the available dates for a specific event. The default shows only dates f
 
 ### Response
 
-The json response contains a list of dates as an array and a meta block.
+The JSON response contains a list of dates as an array and a meta block.
 
 - id (integer), the unique database id of the events' date
 - event_id (integer), the unique database id of the parent event
@@ -526,7 +526,7 @@ registration form.
 
 ### Response
 
-The json response contains more attributes than in the overview:
+The JSON response contains more attributes than in the overview:
 
 - vat_pct (float), the pricing tax rate
 - discount (integer), discount in percent (0-100) to apply on total price for this item if ordered
@@ -622,7 +622,7 @@ curl "https://demo.gomus.de/api/v4/dates"
 
 ### Response
 
-The json response contains a list of dates for all events as an array and a meta block.
+The JSON response contains a list of dates for all events as an array and a meta block.
 
 ## Date languages
 
@@ -653,7 +653,7 @@ curl "https://demo.gomus.de/api/v4/dates/languages"
 
 ### Response
 
-The json response contains a list of all languages used by online bookable date to build up filters.
+The JSON response contains a list of all languages used by online bookable date to build up filters.
 
 
 ## Global events calendar

--- a/source/includes/v4/_exhibitions.md
+++ b/source/includes/v4/_exhibitions.md
@@ -65,7 +65,7 @@ curl "https://demo.gomus.de/api/v4/exhibitions"
 
 ### Response
 
-The json response contains a list of exhibitions as an array and a meta block.
+The JSON response contains a list of exhibitions as an array and a meta block.
 
 - id (integer), the unique database id of the exhibition
 - museum_id (integer), the unique database id of the museum to which the exhibition belongs
@@ -129,7 +129,7 @@ curl "https://demo.gomus.de/api/v4/exhibitions/1"
 
 ### Response
 
-The json response contains an exhibition block with information for that exhibition. The information is the same as that of the exhibitions list response, but with the addition of a location block.
+The JSON response contains an exhibition block with information for that exhibition. The information is the same as that of the exhibitions list response, but with the addition of a location block.
 
 - location, contains information about the location of the exhibition.
 - content, contains key/value pairs of custom defined attributes, e.g. the following:

--- a/source/includes/v4/_museums.md
+++ b/source/includes/v4/_museums.md
@@ -54,7 +54,7 @@ curl "https://demo.gomus.de/api/v4/museums"
 
 ### Response
 
-The json response contains a list of museums as an array and a meta block.
+The JSON response contains a list of museums as an array and a meta block.
 
 - id (integer), the unique database id of the museum
 - title (string), the name of the museum
@@ -105,7 +105,7 @@ curl "https://demo.gomus.de/api/v4/museums/1"
 
 ### Response
 
-The json response contains a museum block with information for that museum. The information is the same as that of the museums list response, but with the addition of a location block.
+The JSON response contains a museum block with information for that museum. The information is the same as that of the museums list response, but with the addition of a location block.
 
 - location, contains information about the location of the museum.
 - content, contains key/value pairs of custom defined attributes, e.g. the following:
@@ -148,4 +148,4 @@ curl "https://demo.gomus.de/api/v4/museums/1/opening_hours?date=2016-12-31"
 
 ### Response
 
-The json response contains the begin and end of the opening hours as datetimes.
+The JSON response contains the begin and end of the opening hours as datetimes.

--- a/source/includes/v4/_other_data.md
+++ b/source/includes/v4/_other_data.md
@@ -48,7 +48,7 @@ curl "https://demo.gomus.de/api/v4/countries"
 
 ### Response
 
-The json response contains a list of countries as an array and a meta block.
+The JSON response contains a list of countries as an array and a meta block.
 
 - name (string), the name of the country
 - id (integer), the unique database id of the country
@@ -110,7 +110,7 @@ curl "https://demo.gomus.de/api/v4/states"
 
 ### Response
 
-The json response contains a list of states as an array and a meta block.
+The JSON response contains a list of states as an array and a meta block.
 
 - name (string), the name of the state
 - id (integer), the unique database id of the state
@@ -157,7 +157,7 @@ curl "https://demo.gomus.de/api/v4/dispatch_modes"
 
 ### Response
 
-The json response contains a list of dispatch modes as an array and a meta block.
+The JSON response contains a list of dispatch modes as an array and a meta block.
 
 - name (string), the name of the dispatch mode
 - id (integer), the unique database id of the dispatch mode

--- a/source/includes/v4/_tickets.md
+++ b/source/includes/v4/_tickets.md
@@ -64,7 +64,7 @@ curl "https://demo.gomus.de/api/v4/tickets"
 
 ### Response
 
-The json response contains a list of tickets as an array and a meta block.
+The JSON response contains a list of tickets as an array and a meta block.
 
 - id (integer), the unique database id of the ticket
 - title (string), the name of the ticket
@@ -146,7 +146,7 @@ curl "https://demo.gomus.de/api/v4/tickets/1"
 
 ### Response
 
-The json response contains a ticket block with information for that the information is the same as that of the tickets list response, but with the addition of a couple of keys.
+The JSON response contains a ticket block with information for that the information is the same as that of the tickets list response, but with the addition of a couple of keys.
 
 - after_sale_information (string), information to be shown after the sale of a ticket. Can contain html elements.
 - location, contains information about the location of the museum that the ticket belongs to.
@@ -184,7 +184,7 @@ curl "https://demo.gomus.de/api/v4/tickets/1/capacity"
 }
 ```
 
-Using the json response on the right as an example, between 11.00 and 11.30 on the 6th July 2016,
+Using the JSON response on the right as an example, between 11.00 and 11.30 on the 6th July 2016,
 the maximum bookable quantity is 15. If only one available time slot is returned, as is the case for day
 tickets, the time range is up untill the end of the day.
 
@@ -195,7 +195,7 @@ tickets, the time range is up untill the end of the day.
 
 ### Response
 
-The json response contains a data block of available time slots and capacities as a hash (key/value pairs). For day tickets, the first possible entry will be returned.
+The JSON response contains a data block of available time slots and capacities as a hash (key/value pairs). For day tickets, the first possible entry will be returned.
 
 The capacity check takes all quotas that the ticket belongs to into account. Zero values are not returned.
 
@@ -427,6 +427,6 @@ curl "https://demo.gomus.de/api/v4/tickets/content?ticket_ids[]=14&ticket_ids[]=
 
 ### Response
 
-The json response contains a list of contents for a set of tickets as an array and a meta block.
+The JSON response contains a list of contents for a set of tickets as an array and a meta block.
 
 - content, contains key/value pairs of a specific attribute per set of tickets

--- a/source/includes/v4/_tours.md
+++ b/source/includes/v4/_tours.md
@@ -29,7 +29,7 @@ curl "https://demo.gomus.de/api/v4/tours/categories"
 
 ### Response
 
-The json response contains a list of all tour categories to build up filters.
+The JSON response contains a list of all tour categories to build up filters.
 Note: this only contains valid elements, some events might have no name set. Some categories have
 duplicate names.
 
@@ -60,7 +60,7 @@ curl "https://demo.gomus.de/api/v4/tours/languages"
 
 ### Response
 
-The json response contains a list of all languages used by online bookable tour products to build up filters.
+The JSON response contains a list of all languages used by online bookable tour products to build up filters.
 
 ## Tour tags
 
@@ -195,7 +195,7 @@ curl "https://demo.gomus.de/api/v4/tours/grades"
 
 ### Tag responses
 
-The json response contains a list of used tour tags by category to build up filters.
+The JSON response contains a list of used tour tags by category to build up filters.
 
 
 ## List of tours
@@ -292,7 +292,7 @@ curl "https://demo.gomus.de/api/v4/tours"
 
 ### Response
 
-The json response contains a list of tours as an array and a meta block.
+The JSON response contains a list of tours as an array and a meta block.
 
 - id (integer), the unique database id of the tour
 - title (string), the name of the tour
@@ -488,7 +488,7 @@ plus additional surcharges, e.g. sunday extra, foreign language extra and so on.
 ### Response
 
 
-The json response contains the following attributes:
+The JSON response contains the following attributes:
 
 - vat_pct (float), the pricing tax rate
 - discount (integer), discount in percent (0-100) to apply on total price for this item if ordered

--- a/source/reseller_api.html.md
+++ b/source/reseller_api.html.md
@@ -77,7 +77,7 @@ curl "https://demo.gomus.de/api/v4/orders"
 
 ### Response
 
-The json response contains a list of existing orders as an array and a meta block.
+The JSON response contains a list of existing orders as an array and a meta block.
 
 - id (integer), the unique database id of the order
 - token (string), a unique token of the order, see more at the documents section


### PR DESCRIPTION
JSON is an acronym for JavaScript Object Notation and so should be
uppercase.

This commit searchs for all uses of the word "json" in a sentance and
changes corrects it to uppercase JSON