### PR TITLE
API V4 : Update tours prices to include vat pct per price

### DIFF
--- a/source/includes/v4/_tours.md
+++ b/source/includes/v4/_tours.md
@@ -454,7 +454,8 @@ curl "https://demo.gomus.de/api/v4/tours/1/prices"
             "description": "Gruppenpreis",
             "group": true,
             "optional": false,
-            "price_cents": 9000
+            "price_cents": 9000,
+            "vat_pct": 0.00
         },
         {
             "price_surcharge_id": 1,
@@ -462,7 +463,8 @@ curl "https://demo.gomus.de/api/v4/tours/1/prices"
             "description": "für Sonn- und Feiertage",
             "group": true,
             "optional": true,
-            "price_cents": 300
+            "price_cents": 300,
+            "vat_pct": 0.00
         }
     ],
     "vat_pct": 0.0,
@@ -504,13 +506,14 @@ and an array of "prices", see below.
 
 The prices block contains one or more price object in an array. There are four types of prices for tour bookings:
 
-default prices with three attributes:
+default prices with four attributes:
 
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
+- vat_pct (float), the pricing tax rate
 
-or scale prices with six attributes:
+or scale prices with seven attributes:
 
 - scale_price_id (integer) internal database id for the scale price definition
 - title (string) title of the scale price, e.g. "regular fee" or "reduced fee"
@@ -518,14 +521,16 @@ or scale prices with six attributes:
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
+- vat_pct (float), the pricing tax rate
 
-or customer type related prices with five attributes:
+or customer type related prices with six attributes:
 
 - title(string) title of price, e.g. "Entgelt" or "Pauschale"
 - description(text)
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
+- vat_pct (float), the pricing tax rate
 
 
 Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges:
@@ -537,6 +542,7 @@ Usualy, only one of the three above occurs per tour. The tour might also be conf
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
+- vat_pct (float), the pricing tax rate
 
 
 ## Start times

--- a/source/includes/v4/_tours.md
+++ b/source/includes/v4/_tours.md
@@ -533,7 +533,7 @@ or customer type related prices with six attributes:
 - vat_pct (float), the pricing tax rate
 
 
-Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges[^1]:
+Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges (Each surcharge will also display a relevant vat_pct amount (float) i.e. the pricing tax rate):
 
 
 - price_surcharge_id (integer) internal database id for the surcharge definition
@@ -542,8 +542,6 @@ Usualy, only one of the three above occurs per tour. The tour might also be conf
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
-
-[^1] Each surcharge will also display a relevant vat_pct amount (float) of the pricing tax rate.
 
 
 ## Start times

--- a/source/includes/v4/_tours.md
+++ b/source/includes/v4/_tours.md
@@ -533,7 +533,7 @@ or customer type related prices with six attributes:
 - vat_pct (float), the pricing tax rate
 
 
-Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges*:
+Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges[^1]:
 
 
 - price_surcharge_id (integer) internal database id for the surcharge definition
@@ -543,7 +543,7 @@ Usualy, only one of the three above occurs per tour. The tour might also be conf
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
 
-* Each surcharge will also display a relevant vat_pct amount (float) of the pricing tax rate.
+[^1] Each surcharge will also display a relevant vat_pct amount (float) of the pricing tax rate.
 
 
 ## Start times

--- a/source/includes/v4/_tours.md
+++ b/source/includes/v4/_tours.md
@@ -533,7 +533,7 @@ or customer type related prices with six attributes:
 - vat_pct (float), the pricing tax rate
 
 
-Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges:
+Usualy, only one of the three above occurs per tour. The tour might also be configured with one or more surcharges*:
 
 
 - price_surcharge_id (integer) internal database id for the surcharge definition
@@ -542,7 +542,8 @@ Usualy, only one of the three above occurs per tour. The tour might also be conf
 - group (boolean), whether the price is for the whole group or per participant (per seat)
 - optional (boolean), whether the price is a choice or not
 - price_cents (integer) price in EUR cents
-- vat_pct (float), the pricing tax rate
+
+* Each surcharge will also display a relevant vat_pct amount (float) of the pricing tax rate.
 
 
 ## Start times


### PR DESCRIPTION
I have updated the v4 api to include the additional vat_pct information for the tour prices end point for each section: default, scale, customer prices and additional surcharges.